### PR TITLE
new feature - settings for exempt users/groups can be callable

### DIFF
--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -330,6 +330,9 @@ class Command(NoArgsCommand):
         self.user_model_attribute_names = self.user_attribute_map.values()
 
         self.exempt_usernames = getattr(settings, 'LDAP_SYNC_USER_EXEMPT_FROM_SYNC', DEFAULTS['LDAP_SYNC_USER_EXEMPT_FROM_SYNC'])
+        if callable(self.exempt_usernames):
+            self.exempt_usernames = self.exempt_usernames()
+
         self.user_removal_action = getattr(settings, 'LDAP_SYNC_USER_REMOVAL_ACTION', DEFAULTS['LDAP_SYNC_USER_REMOVAL_ACTION'])
         if self.user_removal_action not in USER_REMOVAL_OPTIONS:
             raise ImproperlyConfigured('LDAP_SYNC_USER_REMOVAL_ACTION must be one of {}'.format(USER_REMOVAL_OPTIONS))
@@ -368,6 +371,8 @@ class Command(NoArgsCommand):
             raise ImproperlyConfigured('LDAP_SYNC_GROUP_REMOVAL_ACTION must be one of {}'.format(GROUP_REMOVAL_OPTIONS))
 
         self.exempt_groupnames = getattr(settings, 'LDAP_SYNC_GROUP_EXEMPT_FROM_SYNC', DEFAULTS['LDAP_SYNC_GROUP_EXEMPT_FROM_SYNC'])
+        if callable(self.exempt_groupnames):
+            self.exempt_groupnames = self.exempt_groupnames()
 
         self.sync_groups = getattr(settings, 'LDAP_SYNC_GROUPS', DEFAULTS['LDAP_SYNC_GROUPS'])
 


### PR DESCRIPTION
Seems like a generally useful hook. My specific use case is exempting all the users who are dynamically assigned to the exempt group(s). In settings.py, I have a function returning a simple Queryset of exempt users and I use that function as the value of `LDAP_SYNC_USER_EXEMPT_FROM_SYNC`.
