### PR TITLE
fix Group mapping and skip over Reference result types

### DIFF
--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -103,18 +103,13 @@ class Command(NoArgsCommand):
                           removal_action=self.group_removal_action)
 
     def get_ldap_group_membership(self, user_dn):
-        '''
-        Retrieve a list of django groups id's that this user DN is a member of.
-        '''
+        """Retrieve django group ids that this user DN is a member of."""
         if not hasattr(self, '_group_cache'):
-            with connection.cursor() as c:
-                c.execute('SELECT distinguished_name, obj_id FROM ldap3_sync_ldapgroup')
-                r = c.fetchall()
-                self._group_cache = dict(r)
+            r = LDAPGroup.objects.all().values_list('distinguished_name', 'obj')
+            self._group_cache = dict(r)
         logger.debug('Retrieving groups that {} is a member of'.format(user_dn))
         ldap_groups = self.smart_ldap_searcher.search(self.group_base, self.group_membership_filter.format(user_dn=escape_bytes(user_dn)), ldap3.SEARCH_SCOPE_WHOLE_SUBTREE, None)
-        group_dns = [i['dn'] for i in ldap_groups if i.get('type') == 'searchResEntry']
-        return filter(None, [self._group_cache.get(i, None) for i in group_dns])
+        return (self._group_cache.get(i['dn']) for i in ldap_groups if i.get('dn'))
 
     def sync_group_membership(self):
         '''
@@ -127,8 +122,8 @@ class Command(NoArgsCommand):
             except LDAPUser.DoesNotExist:
                 logger.warning('Django user with {} = {} does not have a distinguishedName associated'.format(self.username_field, getattr(django_user, self.username_field)))
                 continue
-            django_groups = self.get_ldap_group_membership(user_dn)
-            if not set([g.pk for g in django_user.groups.all()]) == set(django_groups):
+            django_groups = set(self.get_ldap_group_membership(user_dn))
+            if not set([g.pk for g in django_user.groups.all()]) == django_groups:
                 django_user.groups = django_groups
                 django_user.save()
                 self.stdout.write('{} added to {} groups'.format(username, len(django_groups)))

--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -113,7 +113,7 @@ class Command(NoArgsCommand):
                 self._group_cache = dict(r)
         logger.debug('Retrieving groups that {} is a member of'.format(user_dn))
         ldap_groups = self.smart_ldap_searcher.search(self.group_base, self.group_membership_filter.format(user_dn=escape_bytes(user_dn)), ldap3.SEARCH_SCOPE_WHOLE_SUBTREE, None)
-        group_dns = [i['dn'] for i in ldap_groups]
+        group_dns = [i['dn'] for i in ldap_groups if i.get('type') == 'searchResEntry']
         return filter(None, [self._group_cache.get(i, None) for i in group_dns])
 
     def sync_group_membership(self):
@@ -156,6 +156,9 @@ class Command(NoArgsCommand):
         updated_model_count = 0
 
         for ldap_object in ldap_objects:
+            if ldap_object.get('type') != 'searchResEntry':
+                continue
+
             try:
                 value_map = self.generate_value_map(attribute_map, ldap_object['attributes'])
             except MissingLdapField as e:

--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -108,7 +108,7 @@ class Command(NoArgsCommand):
         '''
         if not hasattr(self, '_group_cache'):
             with connection.cursor() as c:
-                c.execute('SELECT distinguished_name, id FROM ldap3_sync_ldapgroup')
+                c.execute('SELECT distinguished_name, obj_id FROM ldap3_sync_ldapgroup')
                 r = c.fetchall()
                 self._group_cache = dict(r)
         logger.debug('Retrieving groups that {} is a member of'.format(user_dn))

--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -122,8 +122,10 @@ class Command(NoArgsCommand):
             except LDAPUser.DoesNotExist:
                 logger.warning('Django user with {} = {} does not have a distinguishedName associated'.format(self.username_field, getattr(django_user, self.username_field)))
                 continue
+
+            user_in = set(django_user.groups.values_list('pk', flat=True))
             django_groups = set(self.get_ldap_group_membership(user_dn))
-            if not set([g.pk for g in django_user.groups.all()]) == django_groups:
+            if user_in != django_groups:
                 django_user.groups = django_groups
                 django_user.save()
                 self.stdout.write('{} added to {} groups'.format(username, len(django_groups)))


### PR DESCRIPTION
_edit_: This PR turned into two things, but it feels less confusing to put them together than make two PRs touching the same code and possibly having a merge conflict.
### Fix Group mapping

Users were being mapped to the LDAPGroup record number. If nothing else 940347b5778d1720b1b754c1bb9a328f28efd744 is necessary.
### skip over Reference result types

Okay, this one I'm not sure on. I'm new to LDAP internals so this could be inappropriate, break convention, etc. Feel free to improve as necessary.

This overcomes two issues stemming from the same cause. I am getting `searchResRef` results included in the search response and they don't have `dn` keys. Here's example output from [ldapsearch](http://linux.die.net/man/1/ldapsearch) on objectClass=group:
`# refldap://DomainDnsZones.domain.local/DC=DomainDnsZones,DC=domain,DC=local`

Error 1:

```
  File "~/.virtualenvs/project/lib/python2.7/site-packages/ldap3_sync/management/commands/syncldap.py", line 120, in get_ldap_group_membership
    group_dns = [i['dn'] for i in ldap_groups]
KeyError: 'dn'
```

Error 2:

```
  File "~/.virtualenvs/project/lib/python2.7/site-packages/ldap3_sync/management/commands/syncldap.py", line 164, in sync_generic
    value_map = self.generate_value_map(attribute_map, ldap_object['attributes'])
KeyError: 'attributes'
```

I looked into `ldap3`, looked around this library, searched around to see if I could filter out reference types and didn't find anything obvious. This works for me by skipping over Reference results, explicitly in once case and implicitly (looking for `dn`) in another. Thoughts?
