### PR TITLE
Enable mechanism for "default attributes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The distinguished name of the container to base the search for users in.
 Default: **No Default -- Required Item**  
 A dictionary of key value pairs where the keys are the names of ldap fields and the values are the names of corresponding django model fields. New users will be created with these fields populated and existing users will have these fields updated. *This dictionary must map the Django User model username field to an LDAP object field.*
 
+***LDAP_SYNC_USER_DEFAULT_ATTRIBUTES***
+Default: `{}`  
+A dictionary of default values for the given user attributes --keys are attributes. If a certain user does not have an attribute, use the one defined in this dictionary.
+
 ***LDAP_SYNC_USER_EXEMPT_FROM_SYNC***  
 Default: `[]`  
 A list of usernames corresponding to Django users who should be excluded from the sync. Useful for Administrative users who do not have a corresponding user in the directory.
@@ -88,6 +92,10 @@ The distinguished name of the container to base the search for groups in.
 ***LDAP_SYNC_GROUP_ATTRIBUTES***  
 Default: **No Default -- Required Item**  
 A dictionary of key value pairs where the keys are the names of LDAP fields and the values are the names of corresponding Django model fields. New groups will be created with these fields populated and existing users will have these fields updated.
+
+***LDAP_SYNC_GROUP_DEFAULT_ATTRIBUTES***
+Default: `{}`  
+A dictionary of default values for the given group attributes --keys are attributes. If a certain group does not have an attribute, use the one defined in this dictionary.
 
 ***LDAP_SYNC_GROUP_REMOVAL_ACTION***  
 Default: `NOTHING`  

--- a/ldap3_sync/management/commands/syncldap.py
+++ b/ldap3_sync/management/commands/syncldap.py
@@ -39,14 +39,15 @@ DEFAULTS = {
     'LDAP_SYNC_USER_REMOVAL_ACTION': NOTHING,
     'USERNAME_FIELD': 'username',
     'LDAP_SYNC_USER_SET_UNUSABLE_PASSWORD': True,
+    'LDAP_SYNC_USER_DEFAULT_ATTRIBUTES': {},
     'LDAP_SYNC_USERS': True,
     'LDAP_SYNC_GROUP_FILTER': '(objectClass=group)',
     'LDAP_SYNC_GROUP_REMOVAL_ACTION': NOTHING,
     'LDAP_SYNC_GROUP_EXEMPT_FROM_SYNC': [],
+    'LDAP_SYNC_GROUP_DEFAULT_ATTRIBUTES': {},
     'LDAP_SYNC_GROUPS': True,
     'LDAP_SYNC_GROUP_MEMBERSHIP': True,
     'LDAP_SYNC_GROUP_MEMBERSHIP_FILTER': '(&(objectClass=group)(member={user_dn}))'
-
 }
 
 
@@ -204,6 +205,8 @@ class Command(BaseCommand):
 
         self.set_unusable_password = getattr(settings, 'LDAP_SYNC_USER_SET_UNUSABLE_PASSWORD', DEFAULTS['LDAP_SYNC_USER_SET_UNUSABLE_PASSWORD'])
 
+        self.user_default_attributes = getattr(settings, 'LDAP_SYNC_USER_DEFAULT_ATTRIBUTES', DEFAULTS['LDAP_SYNC_USER_DEFAULT_ATTRIBUTES'])
+
         self.sync_users = getattr(settings, 'LDAP_SYNC_USERS', DEFAULTS['LDAP_SYNC_USERS'])
 
         # Check to make sure we have assigned a value to the username field
@@ -235,6 +238,8 @@ class Command(BaseCommand):
         self.exempt_groupnames = getattr(settings, 'LDAP_SYNC_GROUP_EXEMPT_FROM_SYNC', DEFAULTS['LDAP_SYNC_GROUP_EXEMPT_FROM_SYNC'])
         if callable(self.exempt_groupnames):
             self.exempt_groupnames = self.exempt_groupnames()
+
+        self.group_default_attributes = getattr(settings, 'LDAP_SYNC_GROUP_DEFAULT_ATTRIBUTES', DEFAULTS['LDAP_SYNC_GROUP_DEFAULT_ATTRIBUTES'])
 
         self.sync_groups = getattr(settings, 'LDAP_SYNC_GROUPS', DEFAULTS['LDAP_SYNC_GROUPS'])
 

--- a/ldap3_sync/tests/tests.py
+++ b/ldap3_sync/tests/tests.py
@@ -112,6 +112,8 @@ class TestConfiguredSynchronizer(TestCase):
             'employeeID': 'employeeID'
         }
 
+        self.attribute_defaults_map = {}
+
         self.exempt_unique_names = [345678, 7890123]
 
         self.removal_action = SUSPEND
@@ -121,6 +123,7 @@ class TestConfiguredSynchronizer(TestCase):
         self.c_s = Synchronizer(ldap_objects=self.ldap_objects,
                                 django_objects=self.django_objects,
                                 attribute_map=self.attribute_map,
+                                attribute_defaults_map=self.attribute_defaults_map,
                                 django_object_model=TestDjangoModel,
                                 unique_name_field=self.unique_name_field,
                                 exempt_unique_names=self.exempt_unique_names,
@@ -158,6 +161,7 @@ class TestConfiguredSynchronizer(TestCase):
         '''When no django objects are passed in, use the django_object_model to extract all models'''
         s = Synchronizer(ldap_objects=self.ldap_objects,
                          attribute_map=self.attribute_map,
+                         attribute_defaults_map=self.attribute_defaults_map,
                          django_object_model=TestDjangoModel,
                          unique_name_field=self.unique_name_field,
                          exempt_unique_names=self.exempt_unique_names,
@@ -170,6 +174,7 @@ class TestConfiguredSynchronizer(TestCase):
         s = Synchronizer(ldap_objects=self.ldap_objects,
                          django_objects=TestDjangoModel.objects.filter(first_name__icontains='e').all(),
                          attribute_map=self.attribute_map,
+                         attribute_defaults_map=self.attribute_defaults_map,
                          django_object_model=TestDjangoModel,
                          unique_name_field=self.unique_name_field,
                          exempt_unique_names=self.exempt_unique_names,
@@ -424,6 +429,8 @@ class TestSynchronization(TestCase):
             'employeeID': 'employeeID'
         }
 
+        self.attribute_defaults_map = {}
+
         self.exempt_unique_names = [345678, 7890123]
 
         self.removal_action = SUSPEND
@@ -433,6 +440,7 @@ class TestSynchronization(TestCase):
         self.s = Synchronizer(ldap_objects=self.ldap_objects,
                               django_objects=self.django_objects,
                               attribute_map=self.attribute_map,
+                              attribute_defaults_map=self.attribute_defaults_map,
                               django_object_model=TestDjangoModel,
                               unique_name_field=self.unique_name_field,
                               exempt_unique_names=self.exempt_unique_names,


### PR DESCRIPTION
Following some comments in #13, this pull request adds this behaviour as a basic feature, controlled throught the settings `LDAP_SYNC_USER_DEFAULT_ATTRIBUTES` and `LDAP_SYNC_GROUP_DEFAULT_ATTRIBUTES`.

Note that I struggled a little bit in order to test it. Because of #14 and some problems. I am ready to redo it if it doesn't work.
